### PR TITLE
automatically import global vars on document save

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__
+*.pyc

--- a/ImportGlobalVars.py
+++ b/ImportGlobalVars.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from os import path
 import FreeCAD
 
@@ -148,10 +145,3 @@ def linkGlobalVarsToDocument(document: FreeCAD.Document) -> None:
         return
 
     document.recompute()
-
-
-def main():
-    linkGlobalVarsToDocument(FreeCAD.ActiveDocument)
-
-
-main()

--- a/ImportGlobalVarsDocumentObserver.py
+++ b/ImportGlobalVarsDocumentObserver.py
@@ -1,0 +1,12 @@
+import FreeCAD
+from ImportGlobalVars import linkGlobalVarsToDocument
+
+
+class ImportGlobalVarsDocumentObserver():
+    def slotStartSaveDocument(self, document: FreeCAD.Document, docName: str) -> None:
+        linkGlobalVarsToDocument(document)
+
+
+def registerObserver() -> None:
+    observer = ImportGlobalVarsDocumentObserver()
+    FreeCAD.addDocumentObserver(observer)

--- a/InitGui.py
+++ b/InitGui.py
@@ -1,0 +1,26 @@
+# @see https://wiki.freecad.org/Macro_at_Startup
+
+import FreeCADGui
+
+
+def registerGlobalVarsImportDocumentObserver(wbName: str) -> None:
+    # Do not run when NoneWorkbench is activated because UI
+    # isn't yet completely there
+    if 'NoneWorkbench' == wbName:
+        return
+
+    # Unregister this startup handler to make sure that
+    # the document observer is only added once.
+    FreeCADGui.getMainWindow().workbenchActivated.disconnect(registerGlobalVarsImportDocumentObserver)
+
+    from ImportGlobalVarsDocumentObserver import registerObserver
+    registerObserver()
+
+# The following 2 lines are important because InitGui.py files are passed
+# to the exec() function and the function to bind wouldn't be visible outside.
+# So explicitly bind it to __main__
+import __main__
+__main__.registerGlobalVarsImportDocumentObserver = registerGlobalVarsImportDocumentObserver
+
+# Register the function to FC startup
+FreeCADGui.getMainWindow().workbenchActivated.connect(registerGlobalVarsImportDocumentObserver)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,15 @@
-# FreeCAD Macro Import global vars
+# FreeCAD Mod Import global vars
 
-A FreeCAD macro to import (make a link to) a spreadsheet containing vars to be
-used for the whole project. The spreadsheet location is defined in a `FCProject`
-file at the root of your project dir.
+A FreeCAD mod to automatically import (make a link to) a spreadsheet
+containing the vars to be used for the whole project.
+The spreadsheet location is defined in a `FCProject` file at the root of your
+project dir.
+
+**Installation :**
+
+Clone this repo in the `Mod` directory of your FreeCAD
+[root directory](https://wiki.freecad.org/Installing_more_workbenches).
+
 
 **How to use :**
 
@@ -16,15 +23,16 @@ GLOBAL_VARS_SPREADSHEET_NAME=GlobalVars
 ```
 
 - Create a new .FCStd file in your project and save it.
-- Invoke the macro : the newly created file now has a link to the global
-vars spreadsheet.
+- Result : the newly created file now has a link to the global vars
+spreadsheet.
 
 **What it does :**
 
-It looks up for the `FCProject` file and parses it to retrieve the location of
-your defined global vars file and spreadsheet name. Then, it opens the global
-vars file and makes a link to its spreadsheet into the currently active
-document.
+When saving a .FCStd document, the mod looks up for the `FCProject` file
+and parses it to retrieve the location of your defined global vars file
+and spreadsheet name.
+Then, it opens the global vars file and makes a link to its spreadsheet into
+the currently active document.
 
 Exemple of a project structure : 
 
@@ -45,17 +53,11 @@ GLOBAL_VARS_FILE_PATH=./model/GlobalVars.FCStd
 GLOBAL_VARS_SPREADSHEET_NAME=GlobalVars
 ```
 
-The use of the macro when the `model/parts/Plate.FCStd` document is opened would
-import the `GlobalVars` spreadsheet into this document.
+When creating ans saving a new document e.g. `./model/parts/Fork.FCStd`, the
+`GlobalVars` spreadsheet is automatically imported into this document.
 
 **Why ?**
 
 In order to avoid to manually import (i.e. make a link to) a spreadsheet
 from an other document into the active one.
 It will speed up the FreeCAD workflow.
-
-**Improvements**
-
-It would be nice to automatically invoke this macro when the document is saved,
-so global vars would be automatically exposed. FreeCAD's document observers
-might be helpful for that.


### PR DESCRIPTION
Instead of invoking a macro to import the gloval vars once the document has been saved, make it automatic !
This commit turns the original macro into a mod (i.e. has the same structure than a workbench), and registers a document observer during FreeCAD startup. This document observers then calls the global vars import function when a document is about to be saved, to add the global vars spreadsheet to it.

So the global vars spreadsheet import is easier for the end user now : simply create and save a new .FCStd file and when you have a FCProject file, the global vars are automatically linked to the .FCStd file when saving it.